### PR TITLE
Graphite: only part of timerange in result #65

### DIFF
--- a/spec/graphite.jest.ts
+++ b/spec/graphite.jest.ts
@@ -19,7 +19,7 @@ describe('correct Graphite query', function() {
 
   it("test simple query with time clause", function () {
     expect(query.metricQuery.getQuery(1534809600000, 1537488000000, 500, 0).url).toBe(
-      `${datasource.url}?target=${target}&from=3:00_20180821&until=3:00_20180921&maxDataPoints=500`
+      `${datasource.url}?target=${target}&from=1534809600&until=1537488000&maxDataPoints=500`
     )
   });
 })

--- a/src/metrics/graphite_metric.ts
+++ b/src/metrics/graphite_metric.ts
@@ -9,8 +9,8 @@ export class GraphiteMetric extends AbstractMetric {
   }
 
   getQuery(from: number, to: number, limit: number, offset: number): MetricQuery {
-    let from_date = Math.floor(from / 1000);
-    let to_date = Math.floor(to / 1000);
+    let fromDate = Math.floor(from / 1000);
+    let toDate = Math.floor(to / 1000);
 
     let fromRegex = /from=[^\&]+/i;
     let untilRegex = /until=[^\&]+/i;
@@ -18,8 +18,8 @@ export class GraphiteMetric extends AbstractMetric {
 
     let query: string = this.datasource.data;
     let replacements: [RegExp, string][] = [
-      [fromRegex, `from=${from_date}`],
-      [untilRegex, `until=${to_date}`],
+      [fromRegex, `from=${fromDate}`],
+      [untilRegex, `until=${toDate}`],
       [limitRegex, `maxDataPoints=${limit}`]
     ];
 

--- a/src/metrics/graphite_metric.ts
+++ b/src/metrics/graphite_metric.ts
@@ -1,7 +1,6 @@
 import { AbstractMetric, Datasource, MetricId, MetricQuery, MetricResults  } from './metric';
 
 import * as _ from 'lodash';
-import * as moment from 'moment';
 
 
 export class GraphiteMetric extends AbstractMetric {
@@ -10,9 +9,8 @@ export class GraphiteMetric extends AbstractMetric {
   }
 
   getQuery(from: number, to: number, limit: number, offset: number): MetricQuery {
-    let moment_format = 'h:mm_YYYYMMDD';
-    let from_date = moment(from).format(moment_format);
-    let to_date = moment(to).format(moment_format);
+    let from_date = Math.floor(from / 1000);
+    let to_date = Math.floor(to / 1000);
 
     let fromRegex = /from=[^\&]+/i;
     let untilRegex = /until=[^\&]+/i;

--- a/src/metrics/metric.ts
+++ b/src/metrics/metric.ts
@@ -29,5 +29,10 @@ export abstract class AbstractMetric {
     public id?: MetricId
   ) {};
   abstract getQuery(from: number, to: number, limit: number, offset: number): MetricQuery;
+  /*
+    from / to - timestamp in ms
+    limit - max number of items in result
+    offset - number of items to skip from timerange start
+  */
   abstract getResults(res): MetricResults;
 }


### PR DESCRIPTION
Fixes #65 

## Problem
Result contains only part of queried dataset
For example, you're trying to query data from 18:00 to 17:00 but only get 18:00 - 9:00
![image](https://user-images.githubusercontent.com/1989898/57851556-89883080-77e9-11e9-8667-3996efdbd226.png)

## Reasons
- `moment` converts data to OS timezone instead of UTC
- we used 12-hour hour format (`h`) instead of 24-hour (`hh`)

## Changes
- use timestamps in seconds instead of formatted data
- fix test
