### PR TITLE
Elasticsearch: 406 error without specifying content-type #71

### DIFF
--- a/src/grafana_service.ts
+++ b/src/grafana_service.ts
@@ -48,6 +48,12 @@ export async function queryByMetric(
 
 async function queryGrafana(query: MetricQuery, apiKey: string) {
   let headers = { Authorization: `Bearer ${apiKey}` };
+
+  if(query.headers !== undefined) {
+    _.merge(headers, query.headers);
+  }
+
+
   let axiosQuery = {
     headers,
     url: query.url,

--- a/src/metrics/elasticsearch_metric.ts
+++ b/src/metrics/elasticsearch_metric.ts
@@ -35,7 +35,8 @@ export class ElasticsearchMetric extends AbstractMetric {
     return {
       url: this.datasource.url,
       method: 'POST',
-      schema: { data }
+      schema: { data },
+      headers: {'Content-Type': `application/json;charset=UTF-8`}
     }
   }
 

--- a/src/metrics/elasticsearch_metric.ts
+++ b/src/metrics/elasticsearch_metric.ts
@@ -36,7 +36,7 @@ export class ElasticsearchMetric extends AbstractMetric {
       url: this.datasource.url,
       method: 'POST',
       schema: { data },
-      headers: {'Content-Type': `application/json;charset=UTF-8`}
+      headers: {'Content-Type': 'application/json'}
     }
   }
 

--- a/src/metrics/metric.ts
+++ b/src/metrics/metric.ts
@@ -13,6 +13,7 @@ export type MetricQuery = {
   url: string;
   method: string;
   schema: any;
+  headers?: any;
 }
 
 export type MetricResults = {


### PR DESCRIPTION
fixes #71 

## Changes

- added optional field `headers`  to `MetricQuery` that will be merged with base headers from `grafana_service` (only authorization now)