### PR TITLE
WIP Don't keep metric response in memory #28

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/jest": "24.0.0",
+    "@types/node": "12.7.1",
     "jest": "24.0.0",
     "ts-jest": "23.10.5",
     "typescript": "3.3.1"


### PR DESCRIPTION
fixes #28 

### Changes
- added slass that keep options (metric, url and api key)
- added method `query` that should return stream with results